### PR TITLE
Clarify string literal requirement

### DIFF
--- a/proposals/stringref/Overview.md
+++ b/proposals/stringref/Overview.md
@@ -25,7 +25,7 @@ find good compromises are "minimal" and "viable".
  3. Allow WebAssembly implementations to efficiently represent strings
     internally in either WTF-8 or WTF-16 encodings
  4. Allow access to WTF-16 code units for Java, Dart, Kotlin and similar languages
- 5. Allow string literals in element sections
+ 5. Allow string literals as constant expressions
 
 ## Definitions
  - *codepoint*: An integer in the range [0,0x10FFFF].


### PR DESCRIPTION
There has been some confusion about the string literal requirement in https://github.com/WebAssembly/binaryen/pull/4768#discussion_r911525282. This change assumes that the idea is that there shall be constant string literal expressions, which in turn can be used like other constant expressions and then lead to further considerations regarding a dedicated section? My interpretation might very well be wrong :)