### PR TITLE
stringview_wtf16.encode returns number of written code units

### DIFF
--- a/proposals/stringref/Overview.md
+++ b/proposals/stringref/Overview.md
@@ -458,10 +458,12 @@ Return the 16-bit code unit at offset *`pos`* in the WTF-16 encoding of
 
 ```
 (stringview_wtf16.encode $memory view:stringview_wtf16 ptr:address pos:i32 len:i32)
+  -> codeunits:i32
 ```
 Write a subsequence of the WTF-16 encoding of *`view`* to memory at
 *`ptr`*, starting at the WTF-16 offset *`pos`*, writing no more than
 *`len`* 16-bit code units.  If *`ptr`* is not two-byte aligned, trap.
+Return the number of code units written.
 
 If *`pos`* is greater than the number of WTF-16 code units in *`view`*,
 it is as if it were instead given as the code unit length.  This


### PR DESCRIPTION
Since the operand is a maximum number of code units to write, it makes
sense to return the number of code units actually written, for the same
reason as string.encode_wtf16.

See #24.