### PR TITLE
Update code unit definition in Overview.md

### DIFF
--- a/proposals/stringref/Overview.md
+++ b/proposals/stringref/Overview.md
@@ -33,10 +33,10 @@ find good compromises are "minimal" and "viable".
  - *unicode scalar value*: A codepoint that is not a surrogate.
  - *character*: An imprecise concept that we try to avoid in this
     document.
- - *code unit*: An indivisible unit of an encoded unicode scalar value.
-    For UTF-8 encodings, an integer in the range [0,0xFF] (a byte); for
-    UTF-16 encodings, an integer in the range [0,0xFFFF]; for UTF-32,
-    the unicode scalar value itself.
+ - *code unit*: The minimal bit combination that can represent a unit of
+    encoded text for processing or interchange. For UTF-8 encodings, an
+    integer in the range [0,0xFF] (a byte); for UTF-16 encodings, an
+    integer in the range [0,0xFFFF]; for UTF-32, the codepoint value.
  - *high surrogate*: A surrogate in the range [0xD800,0xDBFF].
  - *low surrogate*: A surrogate which is not a high surrogate.
  - *surrogate pair*: A sequence of a *high surrogate* followed by a *low


### PR DESCRIPTION
As per the overview, *code unit* is defined as "an indivisible unit of an encoded unicode scalar value". While individual 8-bit, 16-bit or 32-bit code units are indivisible bit combinations, individual units do not represent scalar values. In 16-bit strings for example, a surrogate pair is a divisible combination of two indivisible code units, both surrogates, that are not scalar values. In 8-bit strings, individual code units map to neither scalar values nor code points.

As per Unicode, Glossary:

> [Code Unit](https://www.unicode.org/glossary/#code_unit). The minimal bit combination that can represent a unit of encoded text for processing or interchange. The Unicode Standard uses 8-bit code units in the UTF-8 encoding form, 16-bit code units in the UTF-16 encoding form, and 32-bit code units in the UTF-32 encoding form. (See definition D77 in [Section 3.9, Unicode Encoding Forms](https://www.unicode.org/versions/latest/ch03.pdf#G7404).)

Suggesting to basically copy Unicode's definition and drop the reference to scalar values.